### PR TITLE
Ignore generated binary in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore generated binary
+nwnt


### PR DESCRIPTION
Adds a `.gitignore` file so the binary isn't detected as a change to the repo.
